### PR TITLE
Add sample module for testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,12 @@ Use `Markdown` with an optional `MarkdownComponentFactory` to customize how each
 val elements = MarkdownProcessorImpl().parse(markdownText)
 Markdown(elements)
 ```
+
+## Sample Module
+
+The `sample` module provides a small CLI application demonstrating how to use
+`MarkdownProcessorImpl`. Run it with:
+
+```bash
+./gradlew :sample:run
+```

--- a/markdownparser/build.gradle.kts
+++ b/markdownparser/build.gradle.kts
@@ -22,5 +22,4 @@ dependencies {
     implementation(libs.compose.runtime)
     implementation(libs.compose.foundation)
     implementation(libs.compose.material)
-    implementation(libs.runtime.android)
 }

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -1,0 +1,16 @@
+plugins {
+    alias(libs.plugins.kotlin.jvm)
+    application
+}
+
+kotlin {
+    jvmToolchain(21)
+}
+
+application {
+    mainClass.set("com.gongora.markdown.sample.MainKt")
+}
+
+dependencies {
+    implementation(project(":markdownparser"))
+}

--- a/sample/src/main/kotlin/com/gongora/markdown/sample/Main.kt
+++ b/sample/src/main/kotlin/com/gongora/markdown/sample/Main.kt
@@ -1,0 +1,15 @@
+package com.gongora.markdown.sample
+
+import com.gongora.markdown.parser.MarkdownProcessorImpl
+
+fun main() {
+    val markdown = """
+        # Sample Heading
+
+        This is a **sample** markdown with a link [Google](https://google.com).
+    """.trimIndent()
+
+    val processor = MarkdownProcessorImpl()
+    val elements = processor.parse(markdown)
+    println(elements.joinToString("\n"))
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,3 +21,4 @@ dependencyResolutionManagement {
 
 rootProject.name = "Markdown"
 include(":markdownparser")
+include(":sample")


### PR DESCRIPTION
## Summary
- add a simple `sample` module with a Main entry point
- document how to run the sample module
- remove `runtime-android` dependency from the library
- include new module in settings

## Testing
- `./gradlew build`
- `./gradlew :sample:run`


------
https://chatgpt.com/codex/tasks/task_e_68634ab852cc83339de3d9d094cb1a9c